### PR TITLE
fix(vim treesitter): support functions with field expression names (#…

### DIFF
--- a/queries/vim/aerial.scm
+++ b/queries/vim/aerial.scm
@@ -3,3 +3,9 @@
     name: [(identifier) (scoped_identifier)] @name)
   (#set! "kind" "Function")
   ) @symbol
+
+(function_definition
+  (function_declaration
+    name: (field_expression) @name)
+  (#set! "kind" "Function")
+  ) @symbol

--- a/tests/symbols/vim_test.json
+++ b/tests/symbols/vim_test.json
@@ -28,5 +28,20 @@
       "end_lnum": 4,
       "lnum": 4
     }
+  },
+  {
+    "col": 0,
+    "end_col": 11,
+    "end_lnum": 8,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 7,
+    "name": "s:drawer.delete_line",
+    "selection_range": {
+      "col": 10,
+      "end_col": 30,
+      "end_lnum": 7,
+      "lnum": 7
+    }
   }
 ]

--- a/tests/treesitter/vim_test.vim
+++ b/tests/treesitter/vim_test.vim
@@ -3,3 +3,6 @@ endfunction
 
 function! s:fn_2() abort
 endfunction
+
+function! s:drawer.delete_line() abort
+endfunction


### PR DESCRIPTION
…332)