### PR TITLE
fix: set lsp.diagnostics_trigger_update=false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,9 +518,8 @@ require("aerial").setup({
   },
 
   lsp = {
-    -- Fetch document symbols when LSP diagnostics update.
-    -- If false, will update on buffer changes.
-    diagnostics_trigger_update = true,
+    -- If true, fetch document symbols when LSP diagnostics update.
+    diagnostics_trigger_update = false,
 
     -- Set to false to not update the symbols when there are LSP errors
     update_when_errors = true,

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -327,9 +327,8 @@ OPTIONS                                                           *aerial-option
       },
 
       lsp = {
-        -- Fetch document symbols when LSP diagnostics update.
-        -- If false, will update on buffer changes.
-        diagnostics_trigger_update = true,
+        -- If true, fetch document symbols when LSP diagnostics update.
+        diagnostics_trigger_update = false,
 
         -- Set to false to not update the symbols when there are LSP errors
         update_when_errors = true,

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -313,9 +313,8 @@ local default_options = {
   },
 
   lsp = {
-    -- Fetch document symbols when LSP diagnostics update.
-    -- If false, will update on buffer changes.
-    diagnostics_trigger_update = true,
+    -- If true, fetch document symbols when LSP diagnostics update.
+    diagnostics_trigger_update = false,
 
     -- Set to false to not update the symbols when there are LSP errors
     update_when_errors = true,


### PR DESCRIPTION
Some LSP servers are less than consistent with pushing diagnostics. For this and other reasons, I think tying the symbol refresh to diagnostics is maybe not the best move. The first step I'm going to take is to make the default behavior use a simple change listener, like the treesitter backend. I may eventually deprecate and remove this behavior entirely.